### PR TITLE
ci(deploy): set -e в удалённом блоке деплоя

### DIFF
--- a/.github/scripts/exec-deploy.sh
+++ b/.github/scripts/exec-deploy.sh
@@ -18,6 +18,7 @@ EOF
 scp -i ~/.ssh/ssh-key.pem docker-compose.yaml "${CONNECTION_STR}:${TARGET_DIR}"
 
 ssh -i ~/.ssh/ssh-key.pem $CONNECTION_STR <<EOF
+  set -e
   cd ${TARGET_DIR}
   docker-compose down
   docker-compose pull


### PR DESCRIPTION
Падение docker-compose up теперь роняет пайплайн (set -e на удалённой стороне).